### PR TITLE
Add profile link button to User Details screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/dush1729/cfseeker/ui/screens/UserDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/dush1729/cfseeker/ui/screens/UserDetailsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.automirrored.filled.NavigateNext
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.FirstPage
+import androidx.compose.material.icons.filled.OpenInNew
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material3.Button
@@ -180,6 +181,7 @@ private fun UserDetailsContent(
     var searchQuery by remember { mutableStateOf("") }
     val scope = rememberCoroutineScope()
     val isSyncUserEnabled = remember { viewModel.isSyncUserEnabled() }
+    val uriHandler = LocalUriHandler.current
     val ratingChanges by viewModel.getRatingChangesByHandle(user.handle, searchQuery).collectAsStateWithLifecycle(initialValue = emptyList())
 
     val tabs = listOf("Info", "Ratings")
@@ -316,6 +318,22 @@ private fun UserDetailsContent(
                 )
                 Spacer(modifier = Modifier.size(4.dp))
                 Text("Delete")
+            }
+
+            OutlinedButton(
+                onClick = {
+                    uriHandler.openUri("https://codeforces.com/profile/${user.handle}")
+                },
+                enabled = !isSyncing,
+                modifier = Modifier.weight(1f)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.OpenInNew,
+                    contentDescription = "Profile",
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.size(4.dp))
+                Text("Profile")
             }
 
             Button(


### PR DESCRIPTION
## Summary
- Adds a "Profile" button between the Delete and Sync buttons on the User Details screen
- Opens the user's Codeforces profile (`codeforces.com/profile/{handle}`) in the browser
- Uses `OpenInNew` icon styled as an `OutlinedButton` consistent with the Delete button

Closes #8

## Test plan
- [ ] Open a user's details screen
- [ ] Verify the Profile button appears between Delete and Sync
- [ ] Tap Profile and confirm it opens the correct Codeforces profile URL in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)